### PR TITLE
fix custom titlebar glitching when switching accounts

### DIFF
--- a/assets/css/titlebar.css
+++ b/assets/css/titlebar.css
@@ -8,7 +8,8 @@
 }
 
 /* GoofCord logo */
-[data-windows][__goofcord-custom-titlebar="true"] > [class^="leading"] {
+[data-windows][__goofcord-custom-titlebar="true"] > [class^="leading"]::after {
+    content: "";
     width: 80px;
     mask-image: var(--wordmark-svg);
     mask-repeat: no-repeat;
@@ -16,8 +17,7 @@
     height: 9px;
 }
 
-/* Move top right buttons to the left to make space for
-   max/min/close buttons */
+/* Make space to the right of the top right buttons */
 [data-windows][__goofcord-custom-titlebar="true"] > [class^="trailing"] {
     padding-right: 100px !important;
 }

--- a/assets/css/titlebar.css
+++ b/assets/css/titlebar.css
@@ -7,6 +7,21 @@
     will-change: background-color;
 }
 
+/* GoofCord logo */
+[data-windows][__goofcord-custom-titlebar="true"] > [class^="leading"] {
+    width: 80px;
+    mask-image: var(--wordmark-svg);
+    mask-repeat: no-repeat;
+    background-color: var(--text-muted);
+    height: 9px;
+}
+
+/* Move top right buttons to the left to make space for
+   max/min/close buttons */
+[data-windows][__goofcord-custom-titlebar="true"] > [class^="trailing"] {
+    padding-right: 100px !important;
+}
+
 #titlebar-text {
     will-change: opacity;
     position: absolute;
@@ -32,19 +47,6 @@
     height: 37px;
     z-index: 998;
     transition: background-color 0.25s ease-in;
-}
-
-#window-title {
-    width: 80px;
-    mask-image: var(--wordmark-svg);
-    mask-repeat: no-repeat;
-    background-color: var(--text-muted);
-    height: 9px;
-}
-
-#window-controls-filler {
-    width: 100px;
-    height: 32px;
 }
 
 #window-controls-container {

--- a/assets/css/titlebar.css
+++ b/assets/css/titlebar.css
@@ -17,7 +17,8 @@
     height: 9px;
 }
 
-/* Make space to the right of the top right buttons */
+/* Move top right buttons to the left to make space for
+   max/min/close buttons */
 [data-windows][__goofcord-custom-titlebar="true"] > [class^="trailing"] {
     padding-right: 100px !important;
 }

--- a/src/windows/main/titlebar.ts
+++ b/src/windows/main/titlebar.ts
@@ -73,17 +73,8 @@ function modifyDiscordBar(): void {
 	if (!bar) return;
 	elements.titlebar = bar as HTMLElement;
 
-	const leading = elements.titlebar.querySelector('[class^="leading"]');
-	const trailing = elements.titlebar.querySelector('[class^="trailing"]');
-	if (!leading || !trailing) return;
-
-	const wordmark = document.createElement("div");
-	wordmark.id = "window-title";
-	leading.prepend(wordmark);
-
-	const controlsFiller = document.createElement('div');
-	controlsFiller.id = "window-controls-filler";
-	trailing.append(controlsFiller);
+	// trigger CSS rules that show custom titlebar
+	bar.setAttribute("__goofcord-custom-titlebar", "true");
 }
 
 export async function injectTitlebar(): Promise<void> {
@@ -117,7 +108,9 @@ function checkMainLayer(): void {
 	} else {
 		elements.dragBar.style.display = mainLayer.getAttribute('aria-hidden') === "true" ? "block" : "none";
 
-		if (!elements.titlebar) modifyDiscordBar();
+		// `elements.titlebar` may be uninitialized or may have been deleted from the document
+		// (due to switching accounts etc.) so we check it
+		if (!document.body.contains(elements.titlebar)) modifyDiscordBar();
 	}
 }
 


### PR DESCRIPTION
Fixes #115.

In `modifyDiscordBar()`, instead of adding new elements (logo and space) to the page as GoofCord currently does, this version marks the parent element with `__goofcord-custom-titlebar` attribute, which triggers CSS rules to show the logo and space, which I think is slightly more elegant.