### PR TITLE
Fix macOS screenshare permission handling

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -64,12 +64,19 @@ function setPermissions() {
 		if (process.platform === "darwin" && "mediaTypes" in details) {
 			if (details.mediaTypes?.includes("audio")) {
 				callback(await systemPreferences.askForMediaAccess("microphone"));
+				return;
 			}
 			if (details.mediaTypes?.includes("video")) {
 				callback(await systemPreferences.askForMediaAccess("camera"));
+				return;
 			}
-		} else if (["media", "notifications", "fullscreen", "clipboard-sanitized-write", "openExternal", "pointerLock", "keyboardLock"].includes(permission)) {
-			callback(true);
 		}
+
+		if (["media", "display-capture", "notifications", "fullscreen", "clipboard-sanitized-write", "openExternal", "pointerLock", "keyboardLock"].includes(permission)) {
+			callback(true);
+			return;
+		}
+
+		callback(false);
 	});
 }


### PR DESCRIPTION
## Summary
- allow the `display-capture` permission so Electron can proceed with screen sharing requests
- return immediately after handling macOS microphone/camera prompts to avoid falling through to unrelated permission logic
- explicitly deny unknown permissions instead of leaving the callback unresolved

## Why
This fixes issue #182 where clicking the screenshare button on macOS could appear to do nothing because the permission request flow never completed correctly.

## Testing
- not fully verified locally in a macOS GoofCord runtime
- reviewed the Electron permission flow to ensure every request path now resolves exactly once