### PR TITLE
Prevent audio-enabled screenshares from ending immediately

### DIFF
--- a/src/windows/main/renderer/postVencord/screensharePatch.ts
+++ b/src/windows/main/renderer/postVencord/screensharePatch.ts
@@ -52,26 +52,33 @@ export function patchScreenshare() {
 		// Patchcord
 		const id = await getVirtmic();
 		if (id) {
-			const audio = await navigator.mediaDevices.getUserMedia({
-				audio: {
-					deviceId: {
-						exact: id,
+			try {
+				const audio = await navigator.mediaDevices.getUserMedia({
+					audio: {
+						deviceId: {
+							exact: id,
+						},
+						autoGainControl: false,
+						echoCancellation: false,
+						noiseSuppression: false,
+						channelCount: 2,
+						sampleRate: 48000,
+						sampleSize: 16,
 					},
-					autoGainControl: false,
-					echoCancellation: false,
-					noiseSuppression: false,
-					channelCount: 2,
-					sampleRate: 48000,
-					sampleSize: 16,
-				},
-			});
+				});
 
-			for (const t of stream.getAudioTracks()) {
-				t.stop();
-				stream.removeTrack(t);
+				const replacementTrack = audio.getAudioTracks()[0];
+				if (replacementTrack) {
+					for (const t of stream.getAudioTracks()) {
+						t.stop();
+						stream.removeTrack(t);
+					}
+
+					stream.addTrack(replacementTrack);
+				}
+			} catch (error) {
+				console.warn("[Screenshare] Failed to replace loopback audio track, using the original track instead.", error);
 			}
-
-			stream.addTrack(audio.getAudioTracks()[0]);
 		}
 
 		return stream;


### PR DESCRIPTION
## Summary
- wrap the virtual/loopback audio replacement step in a safe fallback
- keep the original display-media audio track if the replacement capture fails or returns no track
- log the failure instead of rejecting the whole screenshare flow

## Why
This addresses issue #185 where starting a screenshare with audio could immediately terminate the stream. The stream should continue even if the optional replacement audio device cannot be opened.

## Testing
- `oxlint src/windows/main/renderer/postVencord/screensharePatch.ts`
- not fully verified in a Windows GoofCord runtime