### PR TITLE
Handle cancelled screenshare picker as a normal cancel

### DIFF
--- a/src/windows/main/renderer/postVencord/screensharePatch.ts
+++ b/src/windows/main/renderer/postVencord/screensharePatch.ts
@@ -20,10 +20,21 @@ export function patchScreenshare() {
 	}
 
 	navigator.mediaDevices.getDisplayMedia = async function (opts) {
-		const stream = await original.call(this, opts);
+		let stream: MediaStream;
+		try {
+			stream = await original.call(this, opts);
+		} catch (error) {
+			if (error instanceof TypeError && error.message.includes("no video stream was provided")) {
+				throw new DOMException("The screen share picker was closed before a source was selected.", "NotAllowedError");
+			}
+
+			throw error;
+		}
+
 		console.log("Setting stream's content hint and audio device");
 
 		const settings = window.screenshareSettings;
+		if (!settings) return stream;
 		settings.width = Math.round(settings.resolution * (screen.width / screen.height));
 
 		const videoTrack = stream.getVideoTracks()[0];


### PR DESCRIPTION
## Summary
- translate Electron's missing-video-stream TypeError into a normal `NotAllowedError`
- avoid treating a user-cancelled screenshare picker as an unhandled JavaScript error
- return early when no GoofCord screenshare settings were injected

## Why
This addresses issue #196 where backing out of the screenshare UI could throw an error and leave the screenshare flow in a bad state. Cancelling the picker should behave like a normal user cancellation.

## Testing
- `oxlint src/windows/main/renderer/postVencord/screensharePatch.ts`
- not fully verified in a Wayland GoofCord runtime