### PR TITLE
Retry the first Discord navigation when Windows spoofing is enabled

### DIFF
--- a/src/windows/main/main.ts
+++ b/src/windows/main/main.ts
@@ -53,10 +53,12 @@ export async function createMainWindow() {
 
 async function doAfterDefiningTheWindow() {
 	console.log(`${pc.blue("[Window]")} Setting up window...`);
+	const windowsSpoofEnabled = getConfig("spoofWindows");
 
-	void spoofChrome(mainWindow);
+	await spoofChrome(mainWindow);
 
 	void mainWindow.loadURL(getConfig("discordUrl"));
+	if (windowsSpoofEnabled) void mainWindow.webContents.reload();
 
 	mainWindow.on("close", (event) => {
 		if (getConfig("minimizeToTray") || process.platform === "darwin") {


### PR DESCRIPTION
## Summary
- wait for Chrome spoofing to finish before the main window starts navigating
- restore the one-time retry navigation when `Spoof Windows` is enabled
- keep the fix scoped to the VPN-bypass path instead of changing normal startup behavior

## Why
This addresses issue #187 where enabling `Spoof Windows` still did not recover from Discord's Linux VPN blocking. The original workaround depended on sending a second startup navigation once the spoof had been applied.

## Testing
- `oxlint src/windows/main/main.ts`
- not fully verified against a live VPN-blocked Discord session