### PR TITLE
Fix backing out of the screenshare picker (uncaught error + cannot start a new stream)

### DIFF
--- a/src/windows/main/renderer/postVencord/screensharePatch.ts
+++ b/src/windows/main/renderer/postVencord/screensharePatch.ts
@@ -20,10 +20,20 @@ export function patchScreenshare() {
 	}
 
 	navigator.mediaDevices.getDisplayMedia = async function (opts) {
-		const stream = await original.call(this, opts);
+		let stream: MediaStream;
+		try {
+			stream = await original.call(this, opts);
+		} catch {
+			// Backing out of GoofCord's source picker makes Electron reject getDisplayMedia with a
+			// generic error that Discord doesn't recognize as a cancellation, surfacing it as an
+			// uncaught error. Re-throw "NotAllowedError" — the standard name the web client treats as a
+			// user-cancelled capture — so the error is swallowed and the go-live control re-arms for a retry.
+			throw new DOMException("Permission denied by system", "NotAllowedError");
+		}
 		console.log("Setting stream's content hint and audio device");
 
 		const settings = window.screenshareSettings;
+		if (!settings) return stream;
 		settings.width = Math.round(settings.resolution * (screen.width / screen.height));
 
 		const videoTrack = stream.getVideoTracks()[0];

--- a/src/windows/screenshare/screenshare.ts
+++ b/src/windows/screenshare/screenshare.ts
@@ -129,7 +129,15 @@ export function registerScreenshareHandler() {
 
 		const wcId = capturerWindow.webContents.id;
 
-		activeRequests.set(wcId, { callback, window: capturerWindow, frame: request.frame, initialPromise: fetchScreenshareData(false) });
+		// Acquiring sources triggers the OS screen-share portal on Wayland — the picker shown
+		// *before* our window. If the user dismisses that portal, getSources() rejects (Electron 35+
+		// surfaces the dismissal as a failure). Our window is only shown once sources resolve, so on
+		// that rejection it would never appear and never close — leaving this request's callback
+		// un-fired, which is what blocks Discord from starting a new screenshare. Treat it as a cancel.
+		const initialPromise = fetchScreenshareData(false);
+		initialPromise.catch(() => finishRequest(wcId, {}));
+
+		activeRequests.set(wcId, { callback, window: capturerWindow, frame: request.frame, initialPromise });
 
 		capturerWindow.once("closed", () => {
 			// Idempotent: if select/cancel already ran, the entry is gone and

--- a/src/windows/screenshare/screenshare.ts
+++ b/src/windows/screenshare/screenshare.ts
@@ -16,6 +16,23 @@ interface ActiveRequest {
 
 const activeRequests = new Map<number, ActiveRequest>();
 
+// Single-owner, exactly-once teardown for a screenshare request.
+// The map-delete is the idempotency token: the first caller to reach a live entry
+// owns the callback + window close; every later caller (select/cancel vs. the window
+// `closed` event racing) hits the `!req` guard and is a no-op. Delete BEFORE the
+// callback so a re-entrant `closed` during the callback can't double-fire.
+function finishRequest(wcId: number, result: any) {
+	const req = activeRequests.get(wcId);
+	if (!req) return;
+	activeRequests.delete(wcId);
+	try {
+		req.callback(result);
+	} catch {
+		// Swallow a throw from the Electron callback so teardown (window close) still completes.
+	}
+	if (!req.window.isDestroyed()) req.window.close();
+}
+
 async function fetchScreenshareData(isRefresh = false) {
 	// If it's a manual refresh AND we are on Wayland, skip fetching video sources to prevent re-triggering the OS portal.
 	const skipSources = isRefresh && isWayland;
@@ -52,15 +69,15 @@ export function registerScreenshareHandler() {
 	});
 
 	ipcMain.handle("selectScreenshareSource", async (event, id, name, audioConfig, contentHint, resolution, framerate) => {
-		const req = activeRequests.get(event.sender.id);
+		const wcId = event.sender.id;
+		// Snapshot what we need to read before any `await` — finishRequest owns the
+		// delete + callback + close, so we never pre-delete or call the callback here.
+		const req = activeRequests.get(wcId);
 		if (!req) return;
-
-		activeRequests.delete(event.sender.id);
-		const { callback, window, frame } = req;
+		const { frame } = req;
 
 		if (!id) {
-			callback({});
-			if (!window.isDestroyed()) window.close();
+			finishRequest(wcId, {});
 			return;
 		}
 
@@ -82,8 +99,7 @@ export function registerScreenshareHandler() {
 			}
 		}
 
-		callback(result);
-		if (!window.isDestroyed()) window.close();
+		finishRequest(wcId, result);
 	});
 
 	ipcMain.handle("showScreenshareWindow", (event) => {
@@ -116,10 +132,10 @@ export function registerScreenshareHandler() {
 		activeRequests.set(wcId, { callback, window: capturerWindow, frame: request.frame, initialPromise: fetchScreenshareData(false) });
 
 		capturerWindow.once("closed", () => {
-			if (activeRequests.has(wcId)) {
-				activeRequests.delete(wcId);
-				callback({});
-			}
+			// Idempotent: if select/cancel already ran, the entry is gone and
+			// finishRequest is a no-op (its `!req` guard). Otherwise (OS close button /
+			// window destroyed mid-request) this is the cancel path.
+			finishRequest(wcId, {});
 		});
 
 		capturerWindow.center();


### PR DESCRIPTION
Fixes #196, backing out of the screenshare source picker.

Per the report (filed on KDE/Wayland, also reproduces on Windows), backing out of the "Share screen with GoofCord" popup raises an uncaught `TypeError: Video was requested, but no video stream was provided`, and leaves you unable to start a new stream. The cancel never delivers a clean rejection, so the request stays half-open.

Two files:

- `screensharePatch.ts`: when `getDisplayMedia` rejects on cancellation, re-throw a standard `NotAllowedError` DOMException so Discord's web client treats it as a normal cancel instead of an uncaught error. Also guards a missing `screenshareSettings`.
- `screenshare.ts`: consolidate the picker's teardown paths (the `selectScreenshareSource` IPC handler and the window `closed` event) into a single exactly-once `finishRequest(wcId, result)`, so the callback is delivered once and a new stream can start after backing out. Wayland has an extra wrinkle: the OS xdg-desktop-portal prompt (from `getSources()`) appears before our picker window, and our window is only shown once sources resolve, so dismissing that portal rejects `getSources()` and would otherwise strand the request (window never shown, callback never fired). That rejection now routes through the same `finishRequest`.

Verified by hand on CI builds of this branch:

- Windows x64: cancel the picker, no uncaught error; start a screenshare again, works.
- Wayland (KDE Plasma): same, plus dismissing the OS portal before the picker now lets you start a new screenshare (was previously wedged).

No automated repro exists for the screenshare flow. `bun run check` passes.

Closes #196
