### PR TITLE
Windows screenshare: native system-audio capture that doesn't echo the call

### DIFF
--- a/build/build.ts
+++ b/build/build.ts
@@ -82,6 +82,7 @@ const results = await Promise.all([buildMain(), ...buildRendererScripts(), ...(a
 console.timeEnd("Build");
 
 if (results.every(Boolean)) {
+	await copyNativeAddonsToOutDir();
 	console.log(pc.green("\n✅ Build completed successfully! 🎉\n"));
 } else {
 	console.error(pc.red("\n❌ Build completed with errors.\n"));
@@ -190,6 +191,22 @@ async function copyNativeModules() {
 				{ src: ["venbind", "prebuilds", "linux-aarch64", "venbind-linux-aarch64.node"], platform: "linux", arch: "arm64" },
 			],
 		},
+		// Phase 5 — Windows WASAPI EXCLUDE-tree echo-fix addon, consumed as a published
+		// optionalDependency (github:thomas-quant/wasapi-loopback), mirroring patchcord/venbind.
+		// Phase 5: env override removed; prebuild-only (host-agnostic copy stays — Bun's file-loader
+		// emits zero .node on a Windows build host). bun clones the github ref and the committed
+		// prebuild lands at node_modules/wasapi-loopback/prebuilds/windows-x86_64/wasapi-loopback-win32-x64.node.
+		// CRITICAL (Pitfall 3): with name "wasapi-loopback" the prebuild dest is
+		// `wasapi-loopback-win32-x64.node` on a win32/x64 build — containing BOTH "win32" AND "x64",
+		// exactly what nativeImport.ts's glob substring match needs. A name lacking either substring
+		// would silently emit `export default null` → silent "loopback" fallback (looks like the fix
+		// doesn't work, with no error). The prebuild copy is best-effort (.catch in the prebuild
+		// branch), so a missing prebuild off-Windows (bun skips the win32-only optionalDependency)
+		// never fails the local build.
+		{
+			name: "wasapi-loopback",
+			prebuilds: [{ src: ["wasapi-loopback", "prebuilds", "windows-x86_64", "wasapi-loopback-win32-x64.node"], platform: "win32", arch: "x64" }],
+		},
 	];
 
 	const copyFile = async (src: string, dest: string) => {
@@ -229,4 +246,39 @@ async function copyNativeModules() {
 
 	await Promise.all(tasks);
 	return true;
+}
+
+// Phase 4 — HOST-AGNOSTIC native-addon emission into ts-out/native/.
+//
+// The `native-module:` Bun file-loader (build/nativeImport.ts, `with { type: "file" }`) silently
+// fails to copy the .node into OUT_DIR when the BUILD HOST is Windows (CI windows-latest on bun
+// `latest`): ts-out ends up with ZERO .node files, so every addon resolves to `export default null`
+// → silent "loopback" fallback (Pitfall 3 — looks like the echo fix doesn't work, with no error).
+// A plain fs copy is deterministic across Linux/macOS/Windows build hosts. wasapiLoopback.ts loads
+// the addon from this ts-out/native/ path at runtime (NOT via the file-loader). electron-builder's
+// per-platform `files` filters already key off `ts-out/native/*-<plat>-*.node`, so packaging needs
+// no change. Scoped to wasapi-loopback only; venbind keeps the `native-module:` loader for now.
+// Phase 5: the env override is gone, but this host-agnostic copy STAYS — it is the permanent fix
+// for Bun's Windows-host file-loader bug (zero .node emitted), NOT env-override scaffolding.
+async function copyNativeAddonsToOutDir() {
+	const srcDir = path.join(ASSETS_DIR, "native");
+	const destDir = path.join(OUT_DIR, "native");
+
+	let entries: string[];
+	try {
+		entries = await fs.promises.readdir(srcDir);
+	} catch {
+		return; // nothing staged for this platform → nothing to copy
+	}
+
+	const addons = entries.filter((name) => /^wasapi-loopback-.*\.node$/.test(name));
+	if (addons.length === 0) return;
+
+	await fs.promises.mkdir(destDir, { recursive: true });
+	await Promise.all(
+		addons.map(async (name) => {
+			await Bun.write(path.join(destDir, name), Bun.file(path.join(srcDir, name)));
+			console.log(pc.cyan("Copied native addon into ts-out/native:"), name);
+		}),
+	);
 }

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
       "optionalDependencies": {
         "patchcord": "github:Milkshiift/patchcord",
         "venbind": "0.1.7",
+        "wasapi-loopback": "github:thomas-quant/wasapi-loopback",
       },
       "peerDependencies": {
         "@typescript/native-preview": "^7.0.0-dev.20260425.1",
@@ -746,6 +747,8 @@
     "venbind": ["venbind@0.1.7", "", { "os": [ "linux", "win32", ], "cpu": [ "x64", "arm64", ] }, "sha512-NuKrPYYd7NfMjcmY0xF6ltB/Lka2dV3ZhgFykTgPRlP3qSWmGbaOAmXyp1qPtDoVNAzu7BZkyNXaUqnveuB0tA=="],
 
     "verror": ["verror@1.10.1", "", { "dependencies": { "assert-plus": "^1.0.0", "core-util-is": "1.0.2", "extsprintf": "^1.2.0" } }, "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg=="],
+
+    "wasapi-loopback": ["wasapi-loopback@github:thomas-quant/wasapi-loopback#1ecb8ec", {}, "thomas-quant-wasapi-loopback-1ecb8ec", "sha512-HHsevusMl4Cyv88LszkSHZm/98Sg8m7kfEQoAfBIiWz5fvUgBs5BFNn57DRoZzH4wWO3P+Y7VqhGd9V8YOjEGg=="],
 
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
 

--- a/electron-builder.ts
+++ b/electron-builder.ts
@@ -65,6 +65,12 @@ export const config: Configuration = {
 		},
 		files: [...files, "!ts-out/native/*-linux-*.node", "!ts-out/native/*-win32-*.node"],
 	},
+	// Native addons must live OUTSIDE app.asar — `require()`/`dlopen` cannot load a .node from
+	// inside an asar archive. electron-builder does NOT auto-unpack app-source .node files (only
+	// node_modules native deps), so ts-out/native/*.node (wasapi) and the loader-emitted
+	// ts-out/*.node (venbind) would otherwise be packed unloadable. Unpack all .node to
+	// app.asar.unpacked. (Also fixes venbind's latent Windows packaging gap.)
+	asarUnpack: ["**/*.node"],
 	electronFuses: {
 		runAsNode: false,
 		onlyLoadAppFromAsar: true,

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
 	},
 	"optionalDependencies": {
 		"patchcord": "github:Milkshiift/patchcord",
-		"venbind": "0.1.7"
+		"venbind": "0.1.7",
+		"wasapi-loopback": "github:thomas-quant/wasapi-loopback"
 	},
 	"trustedDependencies": [
 		"electron"

--- a/src/ipc/gen.ts
+++ b/src/ipc/gen.ts
@@ -10,6 +10,7 @@ import { setBadgeCount as ___modules_dynamicIcon_setBadgeCount } from "../module
 import { cycleThroughPasswords as ___modules_messageEncryption_cycleThroughPasswords, decryptMessage as ___modules_messageEncryption_decryptMessage, encryptMessage as ___modules_messageEncryption_encryptMessage } from "../modules/messageEncryption";
 import { stopPatchcord as ___modules_native_patchcord_stopPatchcord } from "../modules/native/patchcord";
 import { isVenbindLoaded as ___modules_native_venbind_isVenbindLoaded, setKeybinds as ___modules_native_venbind_setKeybinds } from "../modules/native/venbind";
+import { shouldInjectWasapiTransport as ___modules_native_wasapiLoopback_shouldInjectWasapiTransport, stopWasapiLoopback as ___modules_native_wasapiLoopback_stopWasapiLoopback } from "../modules/native/wasapiLoopback";
 import { getDisplayVersion as ___utils_getDisplayVersion, getVersion as ___utils_getVersion, isEncryptionAvailable as ___utils_isEncryptionAvailable, saveFileToGCFolder as ___utils_saveFileToGCFolder } from "../utils";
 import { createQuickCssWindow as ___windows_main_quickCssFix_createQuickCssWindow } from "../windows/main/quickCssFix";
 import { deleteCloud as ___windows_settings_cloud_cloud_deleteCloud, loadCloud as ___windows_settings_cloud_cloud_loadCloud, saveCloud as ___windows_settings_cloud_cloud_saveCloud } from "../windows/settings/cloud/cloud";
@@ -41,4 +42,6 @@ export function registerAllHandlers() {
   ipcMain.handle("utils:saveFileToGCFolder", async (event, filePath, content) => { return await ___utils_saveFileToGCFolder(filePath, content); });
   ipcMain.handle("venbind:isVenbindLoaded", async (event) => { return await ___modules_native_venbind_isVenbindLoaded(); });
   ipcMain.handle("venbind:setKeybinds", async (event, keybinds) => { return await ___modules_native_venbind_setKeybinds(keybinds); });
+  ipcMain.on("wasapiLoopback:shouldInjectWasapiTransport", (event) => { event.returnValue = ___modules_native_wasapiLoopback_shouldInjectWasapiTransport(); });
+  ipcMain.handle("wasapiLoopback:stopWasapiLoopback", async (event) => { return await ___modules_native_wasapiLoopback_stopWasapiLoopback(); });
 }

--- a/src/ipc/types.ts
+++ b/src/ipc/types.ts
@@ -9,6 +9,7 @@ import type { setBadgeCount as ___modules_dynamicIcon_setBadgeCount } from "../m
 import type { cycleThroughPasswords as ___modules_messageEncryption_cycleThroughPasswords, decryptMessage as ___modules_messageEncryption_decryptMessage, encryptMessage as ___modules_messageEncryption_encryptMessage } from "../modules/messageEncryption";
 import type { stopPatchcord as ___modules_native_patchcord_stopPatchcord } from "../modules/native/patchcord";
 import type { isVenbindLoaded as ___modules_native_venbind_isVenbindLoaded, setKeybinds as ___modules_native_venbind_setKeybinds } from "../modules/native/venbind";
+import type { shouldInjectWasapiTransport as ___modules_native_wasapiLoopback_shouldInjectWasapiTransport, stopWasapiLoopback as ___modules_native_wasapiLoopback_stopWasapiLoopback } from "../modules/native/wasapiLoopback";
 import type { getDisplayVersion as ___utils_getDisplayVersion, getVersion as ___utils_getVersion, isEncryptionAvailable as ___utils_isEncryptionAvailable, saveFileToGCFolder as ___utils_saveFileToGCFolder } from "../utils";
 import type { createQuickCssWindow as ___windows_main_quickCssFix_createQuickCssWindow } from "../windows/main/quickCssFix";
 import type { deleteCloud as ___windows_settings_cloud_cloud_deleteCloud, loadCloud as ___windows_settings_cloud_cloud_loadCloud, saveCloud as ___windows_settings_cloud_cloud_saveCloud } from "../windows/settings/cloud/cloud";
@@ -34,6 +35,7 @@ export interface IpcHandleChannels {
   "utils:saveFileToGCFolder": typeof ___utils_saveFileToGCFolder;
   "venbind:isVenbindLoaded": typeof ___modules_native_venbind_isVenbindLoaded;
   "venbind:setKeybinds": typeof ___modules_native_venbind_setKeybinds;
+  "wasapiLoopback:stopWasapiLoopback": typeof ___modules_native_wasapiLoopback_stopWasapiLoopback;
 }
 
 export interface IpcOnChannels {
@@ -43,6 +45,7 @@ export interface IpcOnChannels {
   "utils:getDisplayVersion": typeof ___utils_getDisplayVersion;
   "utils:getVersion": typeof ___utils_getVersion;
   "utils:isEncryptionAvailable": typeof ___utils_isEncryptionAvailable;
+  "wasapiLoopback:shouldInjectWasapiTransport": typeof ___modules_native_wasapiLoopback_shouldInjectWasapiTransport;
 }
 
 export interface RegisteredIpcHandleChannels {

--- a/src/modules/native/wasapiLoopback.ts
+++ b/src/modules/native/wasapiLoopback.ts
@@ -1,0 +1,196 @@
+// @ts-nocheck Bun won't install the wasapi-loopback addon on macOS/linux, so typescript can't compile with checks (mirror venbind.ts:1)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Windows WASAPI EXCLUDE-tree echo fix (the #46 fix) — main-process capture wrapper.
+//
+// The clean-room addon (native/wasapi-loopback) captures the full endpoint mix EXCEPT
+// GoofCord's own process tree (the Audio Service child is covered via EXCLUDE_TARGET_PROCESS_TREE),
+// so the viewer hears shared desktop audio but NOT the Discord call echoed back. The captured PCM
+// is forwarded over the canonical Electron MessageChannelMain transport (MessageChannelMain →
+// webContents.postMessage → preload-injected MSTG feeder → viewer).
+//
+// Load model: the addon ships at ts-out/native/wasapi-loopback-<plat>-<arch>.node (placed there by
+// build.ts via a HOST-AGNOSTIC fs copy — NOT Bun's `native-module:` file-loader, which silently
+// fails to emit the .node when the BUILD HOST is Windows). createRequire + a --no-wasapi guard load
+// it; the addon's `start(excludeRootPid, onChunk)` returns false (never throws) when the API is
+// unavailable on this build → we fall through to Electron "loopback" (ECHO-03).
+//
+// On non-win32 / --no-wasapi / addon-not-loaded, tryStartWasapiLoopback returns false
+// immediately so the normal "loopback" path stays byte-identical to upstream.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import { app, MessageChannelMain, type MessagePortMain } from "electron";
+import pc from "picocolors";
+
+import { mainWindow } from "../../windows/main/main.ts";
+
+const require = createRequire(import.meta.url);
+
+const LOG_PREFIX = pc.cyan("[Screenshare]");
+
+// The addon's contract (see native/wasapi-loopback/src/lib.rs):
+//   start(excludeRootPid: number, onChunk: (err, chunk) => void): boolean  // false = unsupported, never throws
+//   stop(): void                                                           // idempotent, bounded join
+interface WasapiAddon {
+	// onChunk is a napi CalleeHandled ThreadsafeFunction → JS is invoked as (err, chunk):
+	// the error slot is the FIRST arg (null on Ok), the audio Buffer is the SECOND.
+	start(excludeRootPid: number, onChunk: (err: unknown, chunk: Buffer) => void): boolean;
+	stop(): void;
+}
+
+// ── Addon load (mirror obtainVenbind: load-once flag + --no-wasapi guard + null-on-failure) ──
+let addon: WasapiAddon | undefined;
+let addonLoadAttempted = false;
+
+// The addon is loaded from ts-out/native/ (placed there by build.ts's host-agnostic copy) via a
+// runtime path anchored at the app root: app.getAppPath() is the project root in dev and the
+// app.asar path when packaged (Electron's require() redirects the unpacked .node automatically).
+// Computing the path here — instead of relying on Bun's `native-module:` file-loader — is what makes
+// a Windows BUILD HOST work; the prior file-loader import emitted ZERO .node on windows-latest.
+const wasapiPath = path.join(app.getAppPath(), "ts-out", "native", `wasapi-loopback-${process.platform}-${process.arch}.node`);
+const wasapiPathExists = existsSync(wasapiPath);
+
+function obtainWasapiLoopback(): WasapiAddon | undefined {
+	if (addon !== undefined || addonLoadAttempted || process.argv.includes("--no-wasapi") || !wasapiPathExists) return addon;
+	addonLoadAttempted = true;
+	try {
+		addon = require(wasapiPath) as WasapiAddon;
+		if (!addon || typeof addon.start !== "function" || typeof addon.stop !== "function") {
+			throw new Error("wasapi-loopback addon missing start/stop exports");
+		}
+		console.log(pc.green("[WASAPI]"), "Loaded wasapi-loopback addon");
+	} catch (e: unknown) {
+		addon = undefined;
+		console.error("Failed to import wasapi-loopback", e);
+	}
+	return addon;
+}
+
+// Whether preload.mts should inject the MSTG feeder + getDisplayMedia swap seam into the Discord
+// page main world. The feeder must be present whenever the addon can run (win32, not --no-wasapi)
+// so the addon's chunks have somewhere to land; otherwise capture silently falls through to the
+// echoing "loopback" path. Read from main via sendSync (the sandboxed preload has no process.argv /
+// authoritative platform). Off-Windows or --no-wasapi ⇒ false ⇒ no injection ⇒ byte-identical to upstream.
+export function shouldInjectWasapiTransport<IPCOn>() {
+	return process.platform === "win32" && !process.argv.includes("--no-wasapi");
+}
+
+// ── State (nulled by stopWasapiLoopback; safe to call stop twice) ────────────────────────
+let port1: MessagePortMain | undefined;
+
+// The addon's onChunk delivers a napi Buffer (480-frame / stereo / f32 = 3840 bytes); forward its
+// bytes down the kept MessagePort. COPY into a fresh ArrayBuffer (the Buffer may share/reuse V8
+// backing memory) so the structured clone over the port is stable.
+function toArrayBuffer(chunk: Buffer): ArrayBuffer {
+	const out = new ArrayBuffer(chunk.byteLength);
+	new Uint8Array(out).set(chunk);
+	return out;
+}
+
+/**
+ * Start the REAL WASAPI EXCLUDE-tree capture behind the proven MessageChannelMain transport.
+ *
+ * Returns false (never throws) on: non-win32, --no-wasapi, addon-not-loaded, addon activation
+ * unsupported on this build, or any exception → the caller falls through to Electron "loopback"
+ * (ECHO-03). On success, the addon's ThreadsafeFunction pushes 480-frame/3840-byte f32 buffers
+ * which we forward down `port1` to the renderer feeder.
+ */
+export async function tryStartWasapiLoopback(): Promise<boolean> {
+	if (process.platform !== "win32" || process.argv.includes("--no-wasapi")) return false;
+
+	const wasapi = obtainWasapiLoopback();
+	if (!wasapi) return false;
+
+	try {
+		// PID discipline (ECHO-02): the EXCLUDE-tree root is the Electron main PID. The addon excludes
+		// the whole tree rooted there via EXCLUDE_TARGET_PROCESS_TREE (covering the Audio Service utility
+		// child) so GoofCord's own call playback never re-enters the captured mix.
+		const rootPid = process.pid;
+
+		// Make start idempotent across re-clicks: tear down any prior session/port first.
+		await stopWasapiLoopback();
+
+		// Hop-1: create the channel, keep port1, transfer port2 to the renderer's preload
+		// (isolated world). MessageChannelMain is the canonical Electron zero-copy audio path —
+		// NEVER per-frame ipcRenderer.send of raw PCM (locked anti-pattern T2).
+		const channel = new MessageChannelMain();
+		port1 = channel.port1;
+		mainWindow.webContents.postMessage("wasapi:pcm-port", null, [channel.port2]);
+		port1.start();
+
+		// Start the REAL addon. start() returns the activation verdict synchronously on the JS side
+		// (false on non-S_OK / missing entrypoint — never throws). The ThreadsafeFunction onChunk runs
+		// per ~10ms with a 3840-byte f32 Buffer, delivered CalleeHandled as (err, chunk): the chunk is
+		// the SECOND arg (the first is the error slot, null on Ok). Guard on err/chunk so a stray error
+		// frame can't crash the callback.
+		const ok = await wasapi.start(rootPid, (err: unknown, chunk: Buffer) => {
+			const port = port1;
+			if (!port || err || !chunk) return;
+			try {
+				// Electron's MAIN-process MessagePortMain.postMessage transfer list accepts ONLY
+				// MessagePortMain instances — NOT ArrayBuffers (unlike the renderer/DOM MessagePort).
+				// Send the buffer as the MESSAGE (structured-cloned, ~384 KB/s — negligible).
+				port.postMessage(toArrayBuffer(chunk));
+			} catch {
+				// A throw inside the threadsafe callback would be an uncaught main-process exception.
+				// Never let the capture crash the app (ECHO-03 discipline): stop cleanly.
+				void stopWasapiLoopback();
+			}
+		});
+
+		if (!ok) {
+			// Activation != S_OK (API unavailable on this build): close the port and fall through
+			// to "loopback" — no crash (ECHO-03). The addon already cleaned up its own thread.
+			await stopWasapiLoopback();
+			return false;
+		}
+
+		console.log(LOG_PREFIX, "WASAPI EXCLUDE-tree capture streaming over MessageChannelMain");
+		return true;
+	} catch {
+		await stopWasapiLoopback();
+		return false; // → "loopback" fallback, never crash (ECHO-03)
+	}
+}
+
+/**
+ * Idempotent teardown: stop the native capture, close the kept port, null state.
+ * Safe to call twice (mirrors stopPatchcord; composes with the single-owner finishRequest).
+ */
+export async function stopWasapiLoopback<IPCHandle>() {
+	// Stop the native capture FIRST so no more chunks arrive after we drop the port. The addon's
+	// stop() is idempotent with a bounded internal join; obtain (cached) without re-loading.
+	const wasapi = addon;
+	if (wasapi) {
+		try {
+			wasapi.stop();
+		} catch {
+			// best-effort; stop() is idempotent and a throw here is non-fatal
+		}
+	}
+
+	const port = port1;
+	port1 = undefined;
+	if (port) {
+		try {
+			port.close();
+		} catch {
+			// already closed
+		}
+		console.log(LOG_PREFIX, "WASAPI EXCLUDE-tree capture stopped");
+	}
+}
+
+// A hung native stop must not wedge quit (mirror patchcord.ts:168-184 Promise.race([dispose, timeout])).
+app.on("before-quit", (event) => {
+	if (!port1 && !addon) return;
+
+	event.preventDefault();
+	Promise.race([stopWasapiLoopback(), new Promise((resolve) => setTimeout(resolve, 1500))])
+		.catch((err) => console.error(LOG_PREFIX, "WASAPI stop failed:", err))
+		.finally(() => app.quit());
+});

--- a/src/windows/main/preload/bridge.ts
+++ b/src/windows/main/preload/bridge.ts
@@ -42,6 +42,9 @@ const api = {
 	openSettingsWindow: () => invoke("settings:createSettingsWindow"),
 	setBadgeCount: (count: number) => invoke("dynamicIcon:setBadgeCount", count),
 	stopPatchcord: () => invoke("patchcord:stopPatchcord"),
+	// Windows WASAPI EXCLUDE-tree echo fix (#46): tears the native capture down from the main-world
+	// getDisplayMedia teardown handler (mirror stopPatchcord).
+	stopWasapiLoopback: () => invoke("wasapiLoopback:stopWasapiLoopback"),
 	isVencordPresent: () => isVencordPresent,
 	onInvidiousConfigChanged: (callback: () => void) => ipcRenderer.on("invidiousConfigChanged", callback),
 	openQuickCssWindow: () => invoke("quickCssFix:createQuickCssWindow"),

--- a/src/windows/main/preload/preload.mts
+++ b/src/windows/main/preload/preload.mts
@@ -1,10 +1,14 @@
 import "./bridge.ts";
 import { getConfig, whenConfigReady } from "@root/src/stores/config/config.preload.ts";
+import { ipcRenderer, webFrame } from "electron";
 
-import { log } from "../../../modules/logger.preload.ts";
+import { sendSync } from "../../../ipc/client.preload.ts";
+import { error, log } from "../../../modules/logger.preload.ts";
 import { loadScripts, loadStyles } from "./assets.ts";
 import { startKeybindWatcher } from "./keybinds.ts";
 import { injectFlashbar } from "./titlebarFlash.ts";
+// Windows WASAPI EXCLUDE-tree echo fix (the #46 fix): the main-world PCM feeder + getDisplayMedia swap seam.
+import { wasapiTransportMainWorldSource } from "./wasapiTransport.ts";
 
 const preloadStart = performance.now();
 
@@ -14,10 +18,58 @@ function init() {
 	loadScripts();
 	loadStyles();
 
+	injectWasapiTransport();
+
 	measureDiscordStartup();
 	injectFlashbar();
 	startKeybindWatcher();
 	disableAltMenu();
+}
+
+// Windows WASAPI EXCLUDE-tree echo fix (the #46 fix).
+// Hop-2 (preload isolated world → page main world): inject the MessagePort-fed MSTG feeder +
+// getDisplayMedia swap seam into the Discord page MAIN WORLD, then forward the hop-1 MessagePort
+// into it via window.postMessage(..., [port]) — but ONLY after the main world signals it has
+// registered its listener (the load-bearing readiness handshake).
+// The gate `shouldInjectWasapiTransport` is true on the win32 wasapi path (not --no-wasapi) so the
+// addon's chunks have a feeder to land in. Off-Windows or --no-wasapi ⇒ no injection, byte-identical
+// to upstream.
+function injectWasapiTransport() {
+	if (!sendSync("wasapiLoopback:shouldInjectWasapiTransport")) return;
+
+	// Buffer the hop-1 port until the main world posts "goofcord:wasapi-ready"; then forward it
+	// zero-copy (DEFAULT mechanism). A port forwarded before the listener exists silently loses
+	// the port + first chunks (Pitfall 1) → viewer hears silence.
+	let pendingPort: MessagePort | undefined;
+	let mainWorldReady = false;
+
+	function forwardPort() {
+		if (!mainWorldReady || !pendingPort) return;
+		const port = pendingPort;
+		pendingPort = undefined;
+		// Zero-copy port→port forward into the injected main world.
+		window.postMessage("goofcord:wasapi-pcm-port", "*", [port]);
+	}
+
+	window.addEventListener("message", (e) => {
+		if (e.data !== "goofcord:wasapi-ready") return;
+		mainWorldReady = true;
+		forwardPort();
+	});
+
+	// Electron delivers the main-process webContents.postMessage (with the transferred port)
+	// to the preload's ipcRenderer. The event carries a native DOM MessagePort in this world.
+	ipcRenderer.on("wasapi:pcm-port", (event) => {
+		const port = (event as unknown as { ports: MessagePort[] }).ports[0];
+		if (!port) return;
+		pendingPort = port;
+		forwardPort();
+	});
+
+	webFrame
+		.executeJavaScript(wasapiTransportMainWorldSource)
+		.then(() => log("Loaded WASAPI Transport"))
+		.catch((err) => error(`Failed WASAPI Transport: ${err}`));
 }
 
 function measureDiscordStartup() {

--- a/src/windows/main/preload/wasapiTransport.ts
+++ b/src/windows/main/preload/wasapiTransport.ts
@@ -1,0 +1,219 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Windows WASAPI EXCLUDE-tree echo fix (the #46 fix) — renderer-side PCM feeder + swap seam.
+//
+// The main process (wasapiLoopback.ts) captures the EXCLUDE-tree PCM and forwards it over a
+// MessagePort. This file is the renderer half: a MessagePort-fed MediaStreamTrackGenerator feeder
+// that reconstructs a live audio track and swaps it into Discord's getDisplayMedia stream at the
+// proven seam, so the viewer hears shared desktop audio but NOT the Discord call echoed back.
+//
+// CI-PACKAGING NOTE: this file lives in the main preload bundle (ts-out/**, which electron-builder
+// packages). preload.mts injects installWasapiTransport into the Discord page MAIN WORLD via
+// webFrame.executeJavaScript (serialized to a string via `.toString()`) ONLY when the wasapi gate is
+// on — NOT placed in the runtime-downloaded postVencord.js. The injected function closes over the
+// page's own globals (MediaStreamTrackGenerator, AudioData, window) which only exist in the main world.
+//
+// HOP-2 (preload isolated world → page main world): preload.mts receives the MessagePort (hop-1) and
+// forwards it via window.postMessage(..., [port]) AFTER this main-world script posts
+// "goofcord:wasapi-ready" (the load-bearing readiness handshake: a port forwarded before the listener
+// exists silently loses the port + first chunks → viewer hears silence).
+//
+// PER-SHARE FEEDER (the #46 second-share regression fix): the swap seam, port listener, and handshake
+// are installed ONCE per page, but the feeder itself (the MediaStreamTrackGenerator track, its writer,
+// and the drain timer) is rebuilt FRESH for every screenshare. Those three primitives are one-shot:
+// Discord ends the track when the share stops, an ended generator can't be revived, and teardown
+// releases the writer + clears the timer. A page-lifetime singleton feeder therefore works for the
+// first share and is permanently dead for every share after — so each forwarded port mints a new
+// Session (see createSession below).
+// ─────────────────────────────────────────────────────────────────────────────
+
+// The entire main-world feeder. Authored as ONE function so it can be serialized with `.toString()`
+// and executed in the page main world (where MediaStreamTrackGenerator, AudioData, and the
+// getDisplayMedia stream live). It reaches the preload bridge via `window.goofcord`
+// (stopWasapiLoopback, to tear the main-process capture down when the share ends).
+export function installWasapiTransport(): void {
+	interface TransportBridge {
+		stopWasapiLoopback: () => unknown;
+	}
+	const bridge = (globalThis as { goofcord?: TransportBridge }).goofcord;
+
+	// Idempotence guard on the page window — injection runs once per page. NOTE: only the swap seam,
+	// the port listener, and the handshake are installed here; the per-share feeder is built in
+	// createSession() on every forwarded port (see the header note on the second-share regression).
+	const flag = "__goofcordWasapiTransportInstalled";
+	if ((globalThis as Record<string, unknown>)[flag]) return;
+	(globalThis as Record<string, unknown>)[flag] = true;
+	if (!bridge) return; // no bridge ⇒ no teardown signal channel; bail (page stays byte-identical)
+
+	const SAMPLE_RATE = 48000;
+	const CHANNELS = 2;
+	const FRAMES = 480; // 10ms @ 48k → ~100 chunks/sec
+	// T4: bounded ring, latency-first. 4-chunk (~40ms) depth absorbs jitter between the main-
+	// process post cadence and the MSTG writer.write() consumption without latency creep.
+	const RING_DEPTH = 4;
+
+	// ── Insertable Streams gate ──────────────────────────────────────────────────────────
+	const MSTG = (globalThis as { MediaStreamTrackGenerator?: unknown }).MediaStreamTrackGenerator;
+	const AD = (globalThis as { AudioData?: unknown }).AudioData;
+	if (typeof MSTG === "undefined" || typeof AD === "undefined") {
+		return; // Insertable Streams unavailable on this build — cannot feed; leave the page untouched.
+	}
+	const GenCtor = MSTG as new (init: { kind: string }) => MediaStreamTrack & { writable: WritableStream };
+	const AudioDataCtor = AD as new (init: Record<string, unknown>) => unknown;
+
+	const intervalMs = (FRAMES / SAMPLE_RATE) * 1000; // ≈10ms drain cadence
+
+	// One screenshare's worth of feeder state. Rebuilt per share (see header note): the track, its
+	// writer, and the drain timer are one-shot, so they cannot be reused across shares.
+	interface Session {
+		track: MediaStreamTrack;
+		teardown: (signalMain: boolean) => void;
+	}
+
+	// The session for the in-flight share. Set when the main process forwards a PCM port (which it
+	// does only when tryStartWasapiLoopback() succeeded) and cleared when that share ends. The swap
+	// seam reads this to decide whether to swap: null ⇒ unsupported build / --no-wasapi / activation
+	// returned false ⇒ leave the original Chromium "loopback" track in place (viewer still hears audio).
+	let current: Session | undefined;
+
+	function createSession(port: MessagePort): Session {
+		const gen = new GenCtor({ kind: "audio" });
+		const writer = gen.writable.getWriter() as WritableStreamDefaultWriter<unknown>;
+		let tsUs = 0; // timestamp MUST be microseconds, monotonic (else frames silently garble)
+
+		// Bounded ring of transferred ArrayBuffers (each = 480*2 interleaved f32 = 3840 bytes).
+		const ring: ArrayBuffer[] = [];
+
+		function writeAudioData(data: Float32Array): void {
+			const ad = new AudioDataCtor({
+				format: "f32",
+				sampleRate: SAMPLE_RATE,
+				numberOfFrames: FRAMES,
+				numberOfChannels: CHANNELS,
+				timestamp: tsUs,
+				data,
+			});
+			tsUs += Math.round((FRAMES / SAMPLE_RATE) * 1e6); // advance ~10000us, monotonic
+			void writer.write(ad);
+		}
+
+		// Drain loop: consume one chunk per ~10ms from the ring; on underrun write a zero-filled
+		// AudioData of the same shape to keep the MSTG timeline monotonic.
+		const drainTimer = setInterval(() => {
+			const ab = ring.shift();
+			if (ab) {
+				writeAudioData(new Float32Array(ab));
+			} else {
+				writeAudioData(new Float32Array(CHANNELS * FRAMES)); // silence fill on underrun
+			}
+		}, intervalMs);
+
+		// Chunks land here: the kept MessagePort delivers transferred ArrayBuffers (3840 bytes) from
+		// the main-process capture. Drop-oldest on overflow (T4).
+		port.onmessage = (msg: MessageEvent) => {
+			if (!(msg.data instanceof ArrayBuffer)) return;
+			if (ring.length >= RING_DEPTH) ring.shift();
+			ring.push(msg.data);
+		};
+		port.start();
+
+		// Exactly-once teardown: both the swapped track AND the video track register an `ended`
+		// handler, and a superseding port can race a late `ended`, so guard against re-entry.
+		let torn = false;
+		function teardown(signalMain: boolean): void {
+			if (torn) return;
+			torn = true;
+			clearInterval(drainTimer);
+			ring.length = 0;
+			try {
+				port.close();
+			} catch {
+				// already closed
+			}
+			try {
+				writer.releaseLock();
+			} catch {
+				// already released
+			}
+			// Tell the main process to stop its native capture ONLY when this share actually ended
+			// (track/video `ended`). On supersede — a new port arrived for a NEW share — the main
+			// process is already driving the replacement capture, so signaling stop here would kill it.
+			if (signalMain) {
+				try {
+					void bridge?.stopWasapiLoopback();
+				} catch {
+					// best-effort
+				}
+			}
+		}
+
+		return { track: gen as MediaStreamTrack, teardown };
+	}
+
+	// ── HOP-2 receiver: a forwarded port = a new capture session ──────────────────────────
+	// The preload forwards the MessagePort via window.postMessage(..., [port]) AFTER it sees our
+	// "goofcord:wasapi-ready" handshake below. A new port means the main process started a fresh
+	// capture, so supersede any still-live session — tear it down LOCALLY (signalMain=false; the
+	// main process is already driving the replacement) and mint a fresh feeder for this share.
+	window.addEventListener("message", (e: MessageEvent) => {
+		if (e.data !== "goofcord:wasapi-pcm-port") return;
+		const port = e.ports[0];
+		if (!port) return;
+		current?.teardown(false);
+		current = createSession(port);
+	});
+
+	// ── SWAP SEAM: wrap getDisplayMedia HERE, in this preload-injected main-world script —
+	// NOT in screensharePatch.ts. postVencord.js is fetched at runtime from upstream `main`
+	// (settingsSchema PostVencord URL), so fork edits to screensharePatch.ts would silently not
+	// ship; only this ts-out-packaged preload reliably reaches the artifact. Injection only happens
+	// when the wasapi gate is on, so with the gate OFF this script is never injected ⇒ the page is
+	// byte-identical to upstream.
+	const md = navigator.mediaDevices;
+	const originalGDM = md.getDisplayMedia.bind(md);
+	md.getDisplayMedia = async function (this: MediaDevices, opts?: DisplayMediaStreamOptions): Promise<MediaStream> {
+		const stream = await originalGDM(opts);
+
+		// ECHO-03 (D-11): only swap when capture is actually active. `current` is set only after
+		// tryStartWasapiLoopback() succeeded and the main process forwarded the port. If it's unset
+		// (unsupported build / --no-wasapi / activation returned false), leave the original Chromium
+		// "loopback" track in place so the viewer hears audio instead of a silence-filled gen track.
+		const session = current;
+		if (!session) return stream;
+
+		try {
+			// On Windows the upstream path leaves the captured "loopback" audio track in the stream
+			// (no virtmic), which is what echoes the call back to viewers. Swap it for the
+			// reconstructed transport track (fed from the main-process MessagePort).
+			for (const t of stream.getAudioTracks()) {
+				t.stop();
+				stream.removeTrack(t);
+			}
+			stream.addTrack(session.track);
+
+			// Teardown trigger: FluxDispatcher STREAM_CLOSE is unavailable in preload-injected
+			// main-world code, so the swapped track or the video track ending tears the feeder + the
+			// main-process native capture down (signalMain=true), and clears `current` so the next
+			// share mints a fresh feeder.
+			const videoTrack = stream.getVideoTracks()[0];
+			const onEnd = () => {
+				session.teardown(true);
+				if (current === session) current = undefined;
+			};
+			session.track.addEventListener("ended", onEnd);
+			if (videoTrack) videoTrack.addEventListener("ended", onEnd);
+		} catch {
+			// Swap failed; leave the original stream as captured (never break the share).
+		}
+		return stream;
+	};
+
+	// READINESS HANDSHAKE (load-bearing): now that the message listener, the per-share feeder
+	// factory, AND the getDisplayMedia swap seam are registered, signal the preload that the main
+	// world is ready to receive the port. The preload buffers the port until it sees this.
+	window.postMessage("goofcord:wasapi-ready", "*");
+}
+
+// Self-contained main-world script string: serialize the feeder and self-invoke it. preload.mts
+// passes this to webFrame.executeJavaScript ONLY when the wasapi gate is on, so it ships from
+// ts-out/** (packaged) yet runs in the page main world.
+export const wasapiTransportMainWorldSource = `(${installWasapiTransport.toString()})();`;

--- a/src/windows/screenshare/screenshare.ts
+++ b/src/windows/screenshare/screenshare.ts
@@ -1,8 +1,12 @@
 import path from "node:path";
 
 import { hasPipewirePulse, patchcordList, patchcordStartApp, patchcordStartSystem } from "@root/src/modules/native/patchcord.ts";
+// Windows WASAPI EXCLUDE-tree echo fix (the #46 fix). Additive 3-way audio gate:
+// Linux patchcord → win32 native exclude-tree → universal "loopback" fallback.
+import { tryStartWasapiLoopback } from "@root/src/modules/native/wasapiLoopback.ts";
 import { BrowserWindow, desktopCapturer, ipcMain, session } from "electron";
 import type { ShareableNode } from "patchcord";
+import pc from "picocolors";
 
 import { dirname, isWayland, relToAbs } from "../../utils.ts";
 import html from "./renderer/screenshare.html";
@@ -77,8 +81,19 @@ export function registerScreenshareHandler() {
 				} catch (err) {
 					console.error("[Screenshare] Failed to start patchcord node:", err);
 				}
+			} else if (process.platform === "win32" && (await tryStartWasapiLoopback())) {
+				// Windows native WASAPI EXCLUDE-tree capture started (the #46 echo fix).
+				// Do NOT also request Chromium "loopback" here. The addon is already running its OWN
+				// WASAPI loopback capture, and a SECOND concurrent WASAPI loopback (Chromium's) fighting
+				// over the same shared Windows audio session corrupts it → CoreMessaging.dll heap-
+				// corruption HARD CRASH on system-audio shares (confirmed: crash only with wasapi ON +
+				// system audio; Chromium loopback alone and the addon alone are each fine). Leaving
+				// result.audio unset means Chromium captures NO audio; the swap seam adds the
+				// reconstructed exclude-tree track to the (audio-less) stream — the addon is the sole
+				// capturer (and the seam discarded Chromium's loopback track anyway, so nothing is lost).
 			} else {
 				result.audio = "loopback";
+				console.log(pc.cyan("[Screenshare]"), "WASAPI process-loopback unsupported on this build, using loopback fallback");
 			}
 		}
 


### PR DESCRIPTION
Adds native Windows system-audio capture for screenshare so sharing system audio no longer echoes the call back to viewers. Closes #46.

Windows has no per-app audio routing (what patchcord gives us on Linux), so the current `"loopback"` path grabs the whole output mix, call included — which the viewer hears echoed back. This captures the same mix with our own call excluded.

The capture is a small Rust addon using the Windows process-loopback API (`ActivateAudioInterfaceAsync` with the exclude-process-tree `AUDCLNT_STREAMOPTIONS`), run in EXCLUDE mode against GoofCord's own process tree. The call audio comes out of the Audio Service child, which is in that tree, so it drops out of the capture while the rest of the desktop audio stays. The Rust side is based on Microsoft's public ApplicationLoopback sample (MIT).

Since we wrap the web client, the PCM has to reach `getDisplayMedia`: the addon's f32 chunks go over a `MessageChannelMain` to a feeder injected into the page main world, which rebuilds the track with `MediaStreamTrackGenerator` and swaps it into the stream. The swap only arms once capture is actually producing audio, so a failed start falls through to loopback. One gotcha: running this and Chromium's own `"loopback"` at once (two loopbacks on one session) hard-crashes in CoreMessaging on system-audio shares, so the win32 path doesn't request Chromium loopback.

The addon ships like venbind/patchcord — its own repo with a `windows-latest` CI that commits a prebuilt `.node`, pulled in via one `optionalDependencies` line (`os: ["win32"]`, so non-Windows skips it). `asarUnpack` is there because electron-builder packs app-source `.node` inside the asar where `require()` can't reach it. Happy to move the repo under the org if you'd rather own it.

If the API isn't available (older Windows) or you pass `--no-wasapi`, it falls back to the existing `"loopback"` — audio works, just the old echo, no crash. Linux/macOS are untouched (the path is behind a `process.platform === "win32"` gate).

Verified by hand on CI builds of this branch (no automated repro for screenshare). Windows 10 19045, two devices on a call: viewer hears the shared desktop audio and no echo; with `--no-wasapi` the echo comes back, so it's this capture doing the work. No crash. `bun run check` passes. Independent of #210.

Closes #46
