### PR TITLE
Fix cloud server repository links

### DIFF
--- a/assets/lang/cs.json
+++ b/assets/lang/cs.json
@@ -49,7 +49,7 @@
     "welcomeMessage": "Vítejte ke GoofCordu!\nNastavte si nastavení k vaší oblibě a restartujte GoofCord pro přístup k Discordu.\nMůžete to udělat pomocí Ctrl+Shift+R nebo přes nabídky v tácku/doku.\nŠťastné povídání!",
     "opt-launchWithOsBoot": "Otevřít GoofCord po spuštění",
     "opt-minimizeToTray": "Minimalizovat do tácku",
-    "opt-cloudHost-desc": "Odkaz na cloudový server GoofCordu. Můžete jej hostovat sami, pro informace navštivte <a target=\"_blank\" href=\"https://github.com/Wuemeli/goofcord-cloudserver\">tuto repozitář</a>.",
+    "opt-cloudHost-desc": "Odkaz na cloudový server GoofCordu. Můžete jej hostovat sami, pro informace navštivte <a target=\"_blank\" href=\"https://codeberg.org/Wuemeli/goofcord-cloudserver\">tuto repozitář</a>.",
     "opt-updateNotification": "Aktualizační oznámení",
     "opt-button-clearCache": "Smazat mezipamět",
     "opt-launchWithOsBoot-desc": "GoofCord se automaticky spustí po zapnutí počítače. V některých Linuxových prostředí nemusí fungovat.",

--- a/assets/lang/de.json
+++ b/assets/lang/de.json
@@ -89,7 +89,7 @@
     "no": "Nein",
     "opt-locale": "Sprache 🌍",
     "opt-cloudHost": "Cloud-Host",
-    "opt-cloudHost-desc": "GoofCord Cloud-Server-URL. Du kannst ihn selbst hosten, sieh dir das <a target=\"_blank\" href=\"https://github.com/Wuemeli/goofcord-cloudserver\">repository</a> an.",
+    "opt-cloudHost-desc": "GoofCord Cloud-Server-URL. Du kannst ihn selbst hosten, sieh dir das <a target=\"_blank\" href=\"https://codeberg.org/Wuemeli/goofcord-cloudserver\">repository</a> an.",
     "inviteMessage": "Willst du beitreten",
     "settings-encryption-unavailable": "GoofCord konnte keinen Passwort-Manager erkennen. Verschlüsselte Einstellungen werden im Klartext gespeichert. Wenn du Linux verwendest, installiere bitte gnome-libsecre* oder kwallet",
     "opt-domOptimizer": "DOM-Optimierer",

--- a/assets/lang/en-US.json
+++ b/assets/lang/en-US.json
@@ -145,7 +145,7 @@
   "opt-autoSaveCloud": "Auto-save",
   "opt-autoSaveCloud-desc": "Automatically saves settings to the cloud when changed.",
   "opt-cloudHost": "Cloud Host URL",
-  "opt-cloudHost-desc": "The URL for the Cloud Server. For self-hosting, see the <a target=\"_blank\" href=\"https://github.com/Wuemeli/goofcord-cloudserver\">repository</a>.",
+  "opt-cloudHost-desc": "The URL for the Cloud Server. For self-hosting, see the <a target=\"_blank\" href=\"https://codeberg.org/Wuemeli/goofcord-cloudserver\">repository</a>.",
   "opt-cloudEncryptionKey": "Cloud Encryption Key",
   "opt-cloudEncryptionKey-desc": "Used to encrypt data sent to the cloud. If lost, your data cannot be recovered. Leave empty to disable encryption and not save message encryption passwords.",
   "opt-button-loadFromCloud": "Load from cloud",

--- a/assets/lang/es.json
+++ b/assets/lang/es.json
@@ -93,7 +93,7 @@
     "yes": "Si",
     "no": "No",
     "opt-cloudHost": "Host en la nube",
-    "opt-cloudHost-desc": "URL del servidor en la nube de GoofCord: ¿Te gustaría hostear GoofCord? Visita el <a target=\"_blank\" href=\"https://github.com/Wuemeli/goofcord-cloudserver\">repositorio oficial</a> para obtener más información y comenzar.",
+    "opt-cloudHost-desc": "URL del servidor en la nube de GoofCord: ¿Te gustaría hostear GoofCord? Visita el <a target=\"_blank\" href=\"https://codeberg.org/Wuemeli/goofcord-cloudserver\">repositorio oficial</a> para obtener más información y comenzar.",
     "category-appearance": "Apariencia",
     "opt-trayIcon": "Icono del tray",
     "opt-autoSaveCloud": "Guardado automático",

--- a/assets/lang/fr.json
+++ b/assets/lang/fr.json
@@ -105,7 +105,7 @@
     "opt-autoSaveCloud": "Sauvegarde automatique",
     "opt-autoSaveCloud-desc": "Sauvegarde automatiquement les paramètres dans le cloud lorsqu'ils changent.",
     "opt-cloudHost": "URL de l'hôte du serveur de cloud",
-    "opt-cloudHost-desc": "L'URL du serveur cloud. Pour l'auto-hébergement, regardez le <a target=\"_blank\" href=\"https://github.com/Wuemeli/goofcord-cloudserver\">repository</a>.",
+    "opt-cloudHost-desc": "L'URL du serveur cloud. Pour l'auto-hébergement, regardez le <a target=\"_blank\" href=\"https://codeberg.org/Wuemeli/goofcord-cloudserver\">repository</a>.",
     "opt-cloudEncryptionKey": "Clé de chiffrement du cloud",
     "opt-cloudEncryptionKey-desc": "Utilisée pour chiffrer les données envoyées dans le cloud. Si perdu, vos données ne pourront plus être récupérées. Laissez vide pour désactiver le chiffrement et ne pas sauvegarder votre mot de passe de chiffrement des messages.",
     "opt-button-loadFromCloud": "Charger depuis le cloud",

--- a/assets/lang/it.json
+++ b/assets/lang/it.json
@@ -101,7 +101,7 @@
     "opt-autoSaveCloud": "Salvataggio Automatico",
     "opt-autoSaveCloud-desc": "Salva automaticamente le impostazioni sul cloud quando vengono modificate.",
     "opt-cloudHost": "Host cloud",
-    "opt-cloudHost-desc": "URL del GoofCord Cloud Server. Puoi ospitarlo autonomamente, vedi il <a target=\"_blank\" href=\"https://github.com/Wuemeli/goofcord-cloudserver\">repository</a>.",
+    "opt-cloudHost-desc": "URL del GoofCord Cloud Server. Puoi ospitarlo autonomamente, vedi il <a target=\"_blank\" href=\"https://codeberg.org/Wuemeli/goofcord-cloudserver\">repository</a>.",
     "opt-cloudEncryptionKey": "Chiave di crittografia cloud",
     "opt-cloudEncryptionKey-desc": "Lascialo vuoto per non usare la crittografia e non salvare le password di crittografia dei messaggi sul cloud. Non potrai recuperare la password se la perdi.",
     "opt-button-loadFromCloud": "Carica dal cloud",

--- a/assets/lang/ja.json
+++ b/assets/lang/ja.json
@@ -39,7 +39,7 @@
     "opt-autoSaveCloud": "自動保存",
     "opt-autoSaveCloud-desc": "設定が変更されたら即座にクラウドに保存する。",
     "opt-cloudHost": "クラウドホストのURL",
-    "opt-cloudHost-desc": "クラウドサーバーのURL。セルフホスティングの場合は<a target=\"_blank\" href=\"https://github.com/Wuemeli/goofcord-cloudserver\">リポジトリ</a>を参照してください。",
+    "opt-cloudHost-desc": "クラウドサーバーのURL。セルフホスティングの場合は<a target=\"_blank\" href=\"https://codeberg.org/Wuemeli/goofcord-cloudserver\">リポジトリ</a>を参照してください。",
     "opt-cloudEncryptionKey": "クラウド暗号鍵",
     "opt-cloudEncryptionKey-desc": "クラウドに送信するデータを暗号化するために使用されます。紛失するとデータは復元できません。 暗号化を無効にしたい場合は空欄のままにしてください。",
     "opt-button-loadFromCloud": "クラウドからロード",

--- a/assets/lang/nds.json
+++ b/assets/lang/nds.json
@@ -93,5 +93,5 @@
     "settings-encryption-unavailable": "GoofCord hett keen Passwort-Manager funnen. Verslüchene Instellen wurrt in Klartext speichert. Wenn du op Linux büst, installeer gnome-libsecret oder kwallet",
     "opt-domOptimizer-desc": "Schiebt DOM-Ännerungen up, üm mööglicherweise de Leistung to verbeteren. Kann visuelle Artefakte veroorzaken.",
     "opt-locale-desc": "Dit is anders as Discord's Sprake. Du kannst GoofCord <a target=\"_blank\" href=\"https://hosted.weblate.org/projects/goofcord/goofcord/\">hier</a> ümschrieven.",
-    "opt-cloudHost-desc": "GoofCord Cloud-Server-URL. Du kannst dat sjelf hosten, kiek dat <a target=\"_blank\" href=\"https://github.com/Wuemeli/goofcord-cloudserver\">repository</a> an."
+    "opt-cloudHost-desc": "GoofCord Cloud-Server-URL. Du kannst dat sjelf hosten, kiek dat <a target=\"_blank\" href=\"https://codeberg.org/Wuemeli/goofcord-cloudserver\">repository</a> an."
 }

--- a/assets/lang/nl.json
+++ b/assets/lang/nl.json
@@ -122,7 +122,7 @@
     "opt-autoSaveCloud": "Automatisch opslaan",
     "opt-autoSaveCloud-desc": "Slaat instellingen automatisch op in de cloud bij veranderingen.",
     "opt-cloudHost": "Cloud Host URL",
-    "opt-cloudHost-desc": "De URL voor de Cloud Server. Om zelf te hosten, zie deze <a target=\"_blank\" href=\"https://github.com/Wuemeli/goofcord-cloudserver\">repository</a>.",
+    "opt-cloudHost-desc": "De URL voor de Cloud Server. Om zelf te hosten, zie deze <a target=\"_blank\" href=\"https://codeberg.org/Wuemeli/goofcord-cloudserver\">repository</a>.",
     "opt-cloudEncryptionKey": "Cloud Encryptiesleutel",
     "opt-cloudEncryptionKey-desc": "Wordt gebruikt om data die naar de cloud wordt verzonden te versleutelen. Als je deze sleutel verliest kan de data niet gerecupereerd worden. Laat leeg om encryptie uit te schakelen en berichtencryptiesleutels niet te bewaren.",
     "opt-button-loadFromCloud": "Laadt vanuit de cloud",

--- a/assets/lang/pl.json
+++ b/assets/lang/pl.json
@@ -107,7 +107,7 @@
     "opt-trayIcon-desc": "Którą ikonę paska zadań użyć. Symboliczne próby naśladowania monochromatycznych ikon Gnome.",
     "opt-messageEncryption-desc": "Sprawdź <a target=\"_blank\" href=\"https://github.com/Milkshiift/GoofCord/wiki/Message-Encryption\">szyfrowanie wiadomości</a>.",
     "opt-encryptionCover": "Krycie szyfrowania",
-    "opt-cloudHost-desc": "Adres URL Serwera Chmury GoofCord. Możesz samodzielnie go hostować, sprawdź <a target=\"_blank\" href=\"https://github.com/Wuemeli/goofcord-cloudserver\">repozytorium</a>.",
+    "opt-cloudHost-desc": "Adres URL Serwera Chmury GoofCord. Możesz samodzielnie go hostować, sprawdź <a target=\"_blank\" href=\"https://codeberg.org/Wuemeli/goofcord-cloudserver\">repozytorium</a>.",
     "goofcord-settings": "Otwórz Ustawienia",
     "opt-staticTitle": "Niezmienny tytuł",
     "opt-staticTitle-desc": "Zapobiega zmianie nazwy okna przez Discorda."

--- a/assets/lang/pt.json
+++ b/assets/lang/pt.json
@@ -93,7 +93,7 @@
     "yes": "Sim",
     "no": "Não",
     "opt-cloudHost": "URL para o host da nuvem",
-    "opt-cloudHost-desc": "A URL para o servidor da nuvem. Veja o <a target=\"_blank\" href=\"https://github.com/Wuemeli/goofcord-cloudserver\">reposiório</a> caso queira usar a sua própria instância.",
+    "opt-cloudHost-desc": "A URL para o servidor da nuvem. Veja o <a target=\"_blank\" href=\"https://codeberg.org/Wuemeli/goofcord-cloudserver\">reposiório</a> caso queira usar a sua própria instância.",
     "menu-development-gcFolder": "Abrir diretório do GoofCord",
     "updateNotification-title": "Há uma atualização disponível ✨",
     "updateNotification-body": "Clique na notificação para ver as notas de lançamento",

--- a/assets/lang/pt_BR.json
+++ b/assets/lang/pt_BR.json
@@ -125,7 +125,7 @@
     "opt-autoSaveCloud": "Envio automático",
     "opt-autoSaveCloud-desc": "Automaticamente envia configurações para a nuvem quando houver mudanças.",
     "opt-cloudHost": "URL para o host da nuvem",
-    "opt-cloudHost-desc": "A URL para o servidor da nuvem. Veja o <a target=\"_blank\" href=\"https://github.com/Wuemeli/goofcord-cloudserver\">reposiório</a> caso queira usar sua própria instância.",
+    "opt-cloudHost-desc": "A URL para o servidor da nuvem. Veja o <a target=\"_blank\" href=\"https://codeberg.org/Wuemeli/goofcord-cloudserver\">reposiório</a> caso queira usar sua própria instância.",
     "opt-cloudEncryptionKey": "Chave de encriptação da nuvem",
     "opt-cloudEncryptionKey-desc": "Usado para encriptar dados enviados para a nuvem. Se perdidos, seus dados não poderão ser restaurados. Deixe o campo vazio para desativar a encriptação e não salvar senhas de mensagens encriptadas.",
     "opt-button-loadFromCloud": "Baixar da nuvem",

--- a/assets/lang/ru.json
+++ b/assets/lang/ru.json
@@ -127,7 +127,7 @@
     "opt-autoSaveCloud": "Автоматическое сохранение",
     "opt-autoSaveCloud-desc": "Автоматически сохраняет настройки в облаке при изменении.",
     "opt-cloudHost": "URL-адрес облачного хостинга",
-    "opt-cloudHost-desc": "URL-адрес Облачного сервера. Информацию о самостоятельном размещении смотрите в <a target=\"_blank\" href=\"https://github.com/Wuemeli/goofcord-cloudserver\">репозитории</a>.",
+    "opt-cloudHost-desc": "URL-адрес Облачного сервера. Информацию о самостоятельном размещении смотрите в <a target=\"_blank\" href=\"https://codeberg.org/Wuemeli/goofcord-cloudserver\">репозитории</a>.",
     "opt-cloudEncryptionKey": "Облачный ключ шифрования",
     "opt-cloudEncryptionKey-desc": "Используется для шифрования данных, отправляемых в облако. В случае потери ваши данные восстановить будет невозможно. Оставьте поле пустым, чтобы отключить шифрование и не сохранять пароли для шифрования сообщений.",
     "opt-button-loadFromCloud": "Загрузка из облака",

--- a/assets/lang/ta.json
+++ b/assets/lang/ta.json
@@ -104,7 +104,7 @@
     "opt-autoSaveCloud": "தானாகச் சேமிக்கவும்",
     "opt-autoSaveCloud-desc": "மேகக்கணியில் அமைப்புகளை மாற்றும்போது தானாகவே சேமிக்கிறது.",
     "opt-cloudHost": "முகில் புரவலன் முகவரி",
-    "opt-cloudHost-desc": "முகில் Serverக்கான URL. சுய-ஓச்டிங்கிற்கு, <a target=\"_blank\" href=\"https://github.com/Wuemeli/goofcord-cloudserver\">களஞ்சியத்தைப்</a> பார்க்கவும்.",
+    "opt-cloudHost-desc": "முகில் Serverக்கான URL. சுய-ஓச்டிங்கிற்கு, <a target=\"_blank\" href=\"https://codeberg.org/Wuemeli/goofcord-cloudserver\">களஞ்சியத்தைப்</a> பார்க்கவும்.",
     "updateNotification-title": "புதிய புதுப்பிப்பு உள்ளது ✨",
     "updateNotification-body": "வெளியீட்டு குறிப்புகளைத் திறக்க அறிவிப்பைக் சொடுக்கு செய்யவும்",
     "settings-dictionary-add": "+ சேர்",

--- a/assets/lang/tr.json
+++ b/assets/lang/tr.json
@@ -128,7 +128,7 @@
     "opt-autoSaveCloud": "Otomatik kaydet",
     "opt-autoSaveCloud-desc": "Ayarlar değiştirildiğinde otomatik olarak buluta kaydedilir.",
     "opt-cloudHost": "Bulut Sunucu URL'si",
-    "opt-cloudHost-desc": "Bulut Sunucu URL'si. Kendi sunucunuzu kurmak (self-hosting) için <a target=\"_blank\" href=\"https://github.com/Wuemeli/goofcord-cloudserver\">depoya</a> göz atın.",
+    "opt-cloudHost-desc": "Bulut Sunucu URL'si. Kendi sunucunuzu kurmak (self-hosting) için <a target=\"_blank\" href=\"https://codeberg.org/Wuemeli/goofcord-cloudserver\">depoya</a> göz atın.",
     "opt-cloudEncryptionKey": "Bulut Şifreleme Anahtarı",
     "opt-cloudEncryptionKey-desc": "Buluta gönderilen verileri şifrelemek için kullanılır. Kaybolması durumunda verileriniz geri döndürülemez. Şifrelemeyi devre dışı bırakmak ve mesaj şifreleme parolalarını kaydetmemek için boş bırakın.",
     "opt-button-loadFromCloud": "Buluttan yükle",

--- a/assets/lang/uk.json
+++ b/assets/lang/uk.json
@@ -93,7 +93,7 @@
     "no": "Ні",
     "yes": "Так",
     "opt-cloudHost": "Хмарний Сервер",
-    "opt-cloudHost-desc": "Посилання на хмарний сервер GoofCord. Ви можете використовувати власний хостинг, дивіться <a target=\"_blank\" href=\"https://github.com/Wuemeli/goofcord-cloudserver\">репозиторій</a>.",
+    "opt-cloudHost-desc": "Посилання на хмарний сервер GoofCord. Ви можете використовувати власний хостинг, дивіться <a target=\"_blank\" href=\"https://codeberg.org/Wuemeli/goofcord-cloudserver\">репозиторій</a>.",
     "opt-renderingOptimizations": "Оптимізації рендерингу",
     "category-appearance": "Вигляд",
     "opt-trayIcon": "Стиль іконки в треї",

--- a/assets/lang/zh_Hant.json
+++ b/assets/lang/zh_Hant.json
@@ -89,7 +89,7 @@
     "no": "不",
     "opt-locale": "語言 🌍",
     "opt-locale-desc": "這與 Discord 的語言不同。您可以在 <a target=\"_blank\" href=\"https://hosted.weblate.org/projects/goofcord/goofcord/\">這裡</a> 翻譯 GoofCord。",
-    "opt-cloudHost-desc": "GoofCord 雲端伺服器 URL。您可以自行架設，請參閱 <a target=\"_blank\" href=\"https://github.com/Wuemeli/goofcord-cloudserver\">倉庫</a>。",
+    "opt-cloudHost-desc": "GoofCord 雲端伺服器 URL。您可以自行架設，請參閱 <a target=\"_blank\" href=\"https://codeberg.org/Wuemeli/goofcord-cloudserver\">倉庫</a>。",
     "opt-cloudHost": "雲端主機",
     "yes": "是的",
     "opt-domOptimizer-desc": "將 DOM 更新延遲以可能提高性能。可能會導致視覺上的瑕疵。",

--- a/src/settingsSchema.ts
+++ b/src/settingsSchema.ts
@@ -435,7 +435,7 @@ export const settingsSchema = {
 		}),
 		cloudHost: setting("textfield", {
 			name: "Cloud Host URL",
-			description: 'The URL for the Cloud Server. For self-hosting, see the <a target="_blank" href="https://github.com/Wuemeli/goofcord-cloudserver">repository</a>.',
+			description: 'The URL for the Cloud Server. For self-hosting, see the <a target="_blank" href="https://codeberg.org/Wuemeli/goofcord-cloudserver">repository</a>.',
 			defaultValue: "https://goofcordcloud.wuemeli.com",
 		}),
 		cloudToken: hidden(""),


### PR DESCRIPTION
Updates outdated goofcord-cloudserver links from GitHub to the project's current Codeberg repository across the settings schema and translations.